### PR TITLE
Totp

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -15,7 +15,7 @@ const {BedrockError} = bedrock.util;
 // load config defaults
 require('./config');
 
-const TOKEN_TYPES = ['password', 'nonce', 'challenge'];
+const TOKEN_TYPES = ['password', 'nonce', 'challenge', 'totp'];
 
 // base58 alphabet; used to improve human readability
 const ALPHABET = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz';

--- a/lib/index.js
+++ b/lib/index.js
@@ -14,6 +14,7 @@ const brPermissionCheck = promisify(brPermission.checkPermission);
 const {config} = bedrock;
 const crypto = require('crypto');
 const database = require('bedrock-mongodb');
+const {authenticator, totp} = require('otplib');
 const {BedrockError} = bedrock.util;
 const {
   generateNonce,
@@ -64,7 +65,7 @@ api.set = async ({
   actor, account, email, type, clientId, hash,
   authenticationMethod = type, requiredAuthenticationMethods = [],
   notify = true
-}) => {
+} = {}) => {
   assert.optionalString(account, 'account');
   assert.optionalString(email, 'email');
   assert.optionalString(clientId, 'clientId');
@@ -81,6 +82,7 @@ api.set = async ({
     requiredAuthenticationMethods
   };
   let challenge;
+  let secret;
 
   if(type === 'password') {
     assert.string(hash, 'hash');
@@ -126,8 +128,27 @@ api.set = async ({
   } else if(type === 'challenge') {
     // TODO: implement
     throw new Error('Not implemented.');
+  } else if(type === 'totp') {
+    // check for existing totp secret
+    let err;
+    try {
+      await api.get({actor: null, account, email, type});
+    } catch(e) {
+      if(e.name !== 'NotFoundError') {
+        throw e;
+      }
+      err = e;
+    }
+    // a NotFoundError is expected here
+    if(!err) {
+      throw new BedrockError(
+        'TOTP authentication token already set.', 'DuplicateError', {
+          httpStatusCode: 409,
+          public: true
+        });
+    }
+    secret = token.secret = authenticator.generateSecret();
   }
-
   await brPermissionCheck(
     actor, PERMISSIONS.ACCOUNT_UPDATE, {resource: [account]});
 
@@ -165,7 +186,14 @@ api.set = async ({
     }
   }
 
-  return {type, challenge};
+  const rValue = {type};
+  if(challenge) {
+    rValue.challenge = challenge;
+  }
+  if(secret) {
+    rValue.secret = secret;
+  }
+  return rValue;
 };
 
 /**
@@ -178,7 +206,7 @@ api.set = async ({
  *
  * @return a Promise that resolves to the token.
  */
-api.get = async ({actor, account, email, type}) => {
+api.get = async ({actor, account, email, type} = {}) => {
   assert.optionalString(account, 'account');
   assert.optionalString(account, 'email');
   if(!(account || email)) {
@@ -218,7 +246,7 @@ api.get = async ({actor, account, email, type}) => {
  *
  * @return a Promise that resolves once the operation completes.
  */
-api.remove = async ({actor, account, type}) => {
+api.remove = async ({actor, account, type} = {}) => {
   assert.string(account, 'account');
   validateTokenType(type);
 
@@ -260,8 +288,8 @@ api.remove = async ({actor, account, type}) => {
  */
 api.verify = async ({
   actor, account, email, type, hash, challenge,
-  authenticatedMethods = []
-}) => {
+  authenticatedMethods = [], totpToken
+} = {}) => {
   assert.optionalString(account, 'account');
   assert.optionalString(account, 'email');
   assert.optionalArrayOfString(authenticatedMethods, 'authenticatedMethods');
@@ -276,8 +304,10 @@ api.verify = async ({
   }
 
   assert.optionalString(challenge, 'challenge');
-  if(!(hash || challenge)) {
-    throw new Error('Either "hash" or "challenge" must be provided.');
+  assert.optionalString(totpToken, 'totpToken');
+  if(!(hash || challenge || totpToken)) {
+    throw new SyntaxError(
+      'One of "hash", "challenge" or "totpToken" must be provided.');
   }
 
   // TODO: could call `api.get()` here if not for the need for
@@ -355,6 +385,10 @@ api.verify = async ({
     verified = crypto.timingSafeEqual(
       new Buffer(token.sha256, 'base64'),
       new Buffer(prefixedHash(hash), 'base64'));
+  } else if(type === 'totp') {
+    // test the totpToken provided to the API against the secret drawn from
+    // the accounts database
+    verified = totp.verify({token: totpToken, secret: token.secret});
   } else {
     if(!challenge) {
       throw new BedrockError(

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
   "homepage": "https://github.com/digitalbazaar/bedrock-authn-token",
   "dependencies": {
     "assert-plus": "^1.0.0",
-    "bcrypt": "kelektiv/node.bcrypt.js#bbf0099fecaffc7c9553dba5d4b4311e2f98fe47"
+    "bcrypt": "kelektiv/node.bcrypt.js#bbf0099fecaffc7c9553dba5d4b4311e2f98fe47",
+    "otplib": "^12.0.1"
   },
   "peerDependencies": {
     "bedrock": "1.12.1 - 3.x",

--- a/test/mocha/20-set-totp.js
+++ b/test/mocha/20-set-totp.js
@@ -1,3 +1,0 @@
-describe('set totp api', () => {
-  it('should work');
-});

--- a/test/mocha/20-totp.js
+++ b/test/mocha/20-totp.js
@@ -1,0 +1,194 @@
+/*
+ * Copyright (c) 2018-2020 Digital Bazaar, Inc. All rights reserved.
+ */
+'use strict';
+
+const brAccount = require('bedrock-account');
+const brAuthnToken = require('bedrock-authn-token');
+const helpers = require('./helpers.js');
+const mockData = require('./mock.data');
+const {totp} = require('otplib');
+
+describe('TOTP API', () => {
+  describe('set', () => {
+    beforeEach(async () => {
+      await helpers.prepareDatabase(mockData);
+    });
+    it('should set a secret', async () => {
+      const accountId = mockData.accounts['alpha@example.com'].account.id;
+      const actor = await brAccount.getCapabilities({id: accountId});
+      let result;
+      let err;
+      try {
+        result = await brAuthnToken.set({
+          account: accountId,
+          actor,
+          type: 'totp',
+        });
+      } catch(e) {
+        err = e;
+      }
+      assertNoError(err);
+      should.exist(result);
+      result.type.should.equal('totp');
+      should.exist(result.secret);
+      result.secret.should.be.a('string');
+    });
+    it('should not set a secret if one already exists', async () => {
+      const accountId = mockData.accounts['alpha@example.com'].account.id;
+      const actor = await brAccount.getCapabilities({id: accountId});
+      await brAuthnToken.set({
+        account: accountId,
+        actor,
+        type: 'totp',
+      });
+      let result;
+      let err;
+      try {
+        result = await brAuthnToken.set({
+          account: accountId,
+          actor,
+          type: 'totp',
+        });
+      } catch(e) {
+        err = e;
+      }
+      should.not.exist(result);
+      should.exist(err);
+    });
+  }); // end set
+
+  describe('verify', () => {
+    const mockAccountEmail = 'alpha@example.com';
+    let secret;
+    let accountId;
+    let actor;
+    before(async () => {
+      await helpers.prepareDatabase(mockData);
+    });
+    // set an OTOP secret
+    before(async () => {
+      accountId = mockData.accounts[mockAccountEmail].account.id;
+      actor = await brAccount.getCapabilities({id: accountId});
+      ({secret} = await brAuthnToken.set({
+        account: accountId,
+        actor,
+        type: 'totp',
+      }));
+    });
+    it('should verify a valid token', async () => {
+      const totpToken = totp.generate(secret);
+      let err;
+      let result;
+      try {
+        result = await brAuthnToken.verify({
+          account: accountId,
+          actor,
+          type: 'totp',
+          totpToken,
+        });
+      } catch(e) {
+        err = e;
+      }
+      assertNoError(err);
+      should.exist(result);
+      result.should.eql({
+        id: accountId,
+        email: mockAccountEmail,
+        token: {type: 'totp', authenticationMethod: 'totp'}
+      });
+    });
+    it('should not verify an invalid token', async () => {
+      // an invalid random totpToken string
+      const totpToken = '91bc2849-2f43-4847-b5ad-01c0436b3a07';
+      let err;
+      let result;
+      try {
+        result = await brAuthnToken.verify({
+          account: accountId,
+          actor,
+          type: 'totp',
+          totpToken,
+        });
+      } catch(e) {
+        err = e;
+      }
+      assertNoError(err);
+      should.exist(result);
+      result.should.be.a('boolean');
+      result.should.be.false;
+    });
+  }); // end verify
+
+  describe('delete', () => {
+    const mockAccountEmail = 'alpha@example.com';
+    let secret;
+    let accountId;
+    let actor;
+    before(async () => {
+      await helpers.prepareDatabase(mockData);
+    });
+    // set an OTOP secret
+    before(async () => {
+      accountId = mockData.accounts[mockAccountEmail].account.id;
+      actor = await brAccount.getCapabilities({id: accountId});
+      ({secret} = await brAuthnToken.set({
+        account: accountId,
+        actor,
+        type: 'totp',
+      }));
+    });
+    it('should delete a secret', async () => {
+      let totpToken = totp.generate(secret);
+      let err;
+      let result;
+      try {
+        result = await brAuthnToken.verify({
+          account: accountId,
+          actor,
+          type: 'totp',
+          totpToken,
+        });
+      } catch(e) {
+        err = e;
+      }
+      assertNoError(err);
+      should.exist(result);
+      result.should.eql({
+        id: accountId,
+        email: mockAccountEmail,
+        token: {type: 'totp', authenticationMethod: 'totp'}
+      });
+
+      err = null;
+      result = null;
+      try {
+        result = await brAuthnToken.remove({
+          account: accountId,
+          actor,
+          type: 'totp',
+        });
+      } catch(e) {
+        err = e;
+      }
+      should.not.exist(err);
+
+      // attempt to validate the TOTP token again
+      totpToken = totp.generate(secret);
+      err = null;
+      result = null;
+      try {
+        result = await brAuthnToken.verify({
+          account: accountId,
+          actor,
+          type: 'totp',
+          totpToken,
+        });
+      } catch(e) {
+        err = e;
+      }
+      should.exist(err);
+      err.name.should.equal('NotFoundError');
+    });
+  }); // end delete
+}); // end totp api

--- a/test/mocha/helpers.js
+++ b/test/mocha/helpers.js
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2018-2020 Digital Bazaar, Inc. All rights reserved.
+ */
+'use strict';
+
+const brAccount = require('bedrock-account');
+const database = require('bedrock-mongodb');
+const {promisify} = require('util');
+
+exports.prepareDatabase = async mockData => {
+  await exports.removeCollections();
+  await _insertTestData(mockData);
+};
+
+exports.removeCollections = async (
+  collectionNames = [
+    'account',
+  ]) => {
+  await promisify(database.openCollections)(collectionNames);
+  for(const collectionName of collectionNames) {
+    await database.collections[collectionName].remove({});
+  }
+};
+
+exports.removeCollection =
+  async collectionName => exports.removeCollections([collectionName]);
+
+async function _insertTestData(mockData) {
+  const records = Object.values(mockData.accounts);
+  for(const record of records) {
+    try {
+      await brAccount.insert(
+        {actor: null, account: record.account, meta: record.meta || {}});
+    } catch(e) {
+      if(e.name === 'DuplicateError') {
+        // duplicate error means test data is already loaded
+        continue;
+      }
+      throw e;
+    }
+  }
+}

--- a/test/mocha/mock.data.js
+++ b/test/mocha/mock.data.js
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2018-2020 Digital Bazaar, Inc. All rights reserved.
+ */
+'use strict';
+
+const {util: {uuid}} = require('bedrock');
+
+const accounts = exports.accounts = {};
+
+// regular permissions
+const email = 'alpha@example.com';
+accounts[email] = {};
+accounts[email].account = _createAccount(email);
+accounts[email].meta = {};
+accounts[email].meta.sysResourceRole = [{
+  sysRole: 'bedrock-test.regular',
+  generateResource: 'id',
+}];
+
+function _createAccount(email) {
+  const newAccount = {
+    id: 'urn:uuid:' + uuid(),
+    email
+  };
+  return newAccount;
+}

--- a/test/package.json
+++ b/test/package.json
@@ -13,6 +13,7 @@
     "bedrock-mongodb": "^6.0.0",
     "bedrock-permission": "^2.5.4",
     "bedrock-test": "^5.0.0",
-    "bedrock-validation": "^4.2.0"
+    "bedrock-validation": "^4.2.0",
+    "otplib": "^12.0.1"
   }
 }

--- a/test/test.config.js
+++ b/test/test.config.js
@@ -12,3 +12,15 @@ config.mongodb.dropCollections.onInit = true;
 config.mongodb.dropCollections.collections = [];
 
 config.mocha.tests.push(path.join(__dirname, 'mocha'));
+
+const {permissions, roles} = config.permission;
+roles['bedrock-test.regular'] = {
+  id: 'bedrock-test.regular',
+  label: 'Account Test Role',
+  comment: 'Role for Test User',
+  sysPermission: [
+    permissions.ACCOUNT_ACCESS.id,
+    permissions.ACCOUNT_UPDATE.id,
+    permissions.ACCOUNT_INSERT.id,
+  ]
+};

--- a/test/test.js
+++ b/test/test.js
@@ -3,6 +3,7 @@
  */
 const bedrock = require('bedrock');
 require('bedrock-authn-token');
+require('bedrock-permission');
 
 require('bedrock-test');
 bedrock.start();


### PR DESCRIPTION
There's some fixme's that need comment, 

One of them (at the bottom of the tests) is to do with the `verify` API returning NotFoundError if the account does not have that sort of authentication token.  I wonder if that's leaking information unnecessarily.  Maybe we just return false in that instance?