### PR TITLE
TOTP Updates

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -62,7 +62,8 @@ const PERMISSIONS = bedrock.config.permission.permissions;
  *   by this API.
  * @param [notify=true] `true` to notify the account user, `false` not to.
  *
- * @return a Promise that resolves once the operation completes.
+ * @return a Promise that resolves once the operation completes with optional
+ *   token details depending on the type.
  */
 api.set = async ({
   actor, account, email, type, clientId, hash,
@@ -87,8 +88,10 @@ api.set = async ({
     authenticationMethod,
     requiredAuthenticationMethods
   };
+  const rValue = {
+    type
+  };
   let challenge;
-  let secret;
 
   if(type === 'password') {
     assert.string(hash, 'hash');
@@ -131,6 +134,9 @@ api.set = async ({
     token.salt = salt;
     token.sha256 = prefixedHash(hash);
     token.expires = new Date(Date.now() + ttl);
+
+    // return challenge
+    rValue.challenge = challenge;
   } else if(type === 'challenge') {
     // TODO: implement
     throw new Error('Not implemented.');
@@ -153,7 +159,26 @@ api.set = async ({
           public: true
         });
     }
-    secret = token.secret = authenticator.generateSecret();
+    // FIXME: save params in token and use explicitly? (algorithm, digits, step)
+    token.secret = authenticator.generateSecret();
+
+    // defaults
+    const allOptions = authenticator.allOptions();
+
+    // return TOTP params
+    // algorithm, digits, period are defaults for otplib 'authenticator'
+    rValue.secret = token.secret;
+      // FIXME: use readable email and service name
+    rValue.label = email || account;
+      // a service name, `undefined` is OK if `serviceId` was not passed in
+    rValue.service = serviceId;
+    rValue.algorithm = allOptions.algorithm.toUpperCase();
+    rValue.digits = allOptions.digits;
+    rValue.period = allOptions.step;
+      // produces a URL like `otpauth://totp/...`
+    rValue.otpAuthUrl = authenticator.keyuri(
+      rValue.label, rValue.service, rValue.secret
+    );
   }
 
   // add token to meta
@@ -190,26 +215,6 @@ api.set = async ({
     }
   }
 
-  const rValue = {type};
-  if(challenge) {
-    rValue.challenge = challenge;
-  }
-  if(secret) {
-    // TOTP params
-    // algorithm, digits, period are defaults for otplib 'authenticator'
-    rValue.secret = secret;
-    // FIXME: use readable email and service name
-    rValue.label = email || account;
-    // a service name, `undefined` is OK if `serviceId` was not passed in
-    rValue.service = serviceId;
-    rValue.algorithm = 'SHA1';
-    rValue.digits = 6;
-    rValue.period = 30;
-    // produces a URL like `otpauth://totp/...`
-    rValue.otpAuthUrl = authenticator.keyuri(
-      rValue.label, rValue.service, rValue.secret
-    );
-  }
   return rValue;
 };
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -159,6 +159,15 @@ api.set = async ({
           public: true
         });
     }
+
+    // get email for use in label/url
+    if(!email) {
+      const record = await brAccount.get({actor, id: account});
+      if(record.account.email) {
+        email = record.account.email;
+      }
+    }
+
     // FIXME: save params in token and use explicitly? (algorithm, digits, step)
     token.secret = authenticator.generateSecret();
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -15,7 +15,7 @@ const {config} = bedrock;
 const crypto = require('crypto');
 const database = require('bedrock-mongodb');
 const jsonpatch = require('fast-json-patch');
-const {authenticator, totp} = require('otplib');
+const {authenticator} = require('otplib');
 const {BedrockError} = bedrock.util;
 const {
   generateNonce,
@@ -195,14 +195,19 @@ api.set = async ({
     rValue.challenge = challenge;
   }
   if(secret) {
+    // TOTP params
+    // algorithm, digits, period are defaults for otplib 'authenticator'
     rValue.secret = secret;
+    // FIXME: use readable email and service name
+    rValue.label = email || account;
+    // a service name, `undefined` is OK if `serviceId` was not passed in
+    rvalue.service = serviceId;
+    rValue.algorithm = 'SHA1';
+    rValue.digits = 6;
+    rValue.period = 30;
     // produces a URL like `otpauth://totp/...`
     rValue.otpAuthUrl = authenticator.keyuri(
-      // user identifier
-      email || account,
-      // a service name, `undefined` is OK if `serviceId` was not passed in
-      serviceId,
-      secret
+      rValue.label, rValue.service, rValue.secret
     );
   }
   return rValue;
@@ -299,13 +304,13 @@ api.remove = async ({actor, account, type} = {}) => {
  *   the account `email` and token information if verified, `false` if not.
  */
 api.verify = async ({
-  actor, account, email, type, hash, challenge,
-  authenticatedMethods = [], totpToken
+  actor, account, email, type, hash, challenge, authenticatedMethods = []
 } = {}) => {
   assert.optionalString(account, 'account');
   assert.optionalString(account, 'email');
   assert.optionalArrayOfString(authenticatedMethods, 'authenticatedMethods');
   if(!(account || email)) {
+    // FIXME: BedrockError
     throw new Error('Either "account" or "email" must be provided.');
   }
   validateTokenType(type);
@@ -316,10 +321,9 @@ api.verify = async ({
   }
 
   assert.optionalString(challenge, 'challenge');
-  assert.optionalString(totpToken, 'totpToken');
-  if(!(hash || challenge || totpToken)) {
+  if(!(hash || challenge)) {
     throw new SyntaxError(
-      'One of "hash", "challenge" or "totpToken" must be provided.');
+      'One of "hash" or "challenge" must be provided.');
   }
 
   // TODO: could call `api.get()` here if not for the need for
@@ -400,7 +404,7 @@ api.verify = async ({
   } else if(type === 'totp') {
     // test the totpToken provided to the API against the secret drawn from
     // the accounts database
-    verified = totp.verify({token: totpToken, secret: token.secret});
+    verified = authenticator.verify({token: challenge, secret: token.secret});
   } else {
     if(!challenge) {
       throw new BedrockError(

--- a/lib/index.js
+++ b/lib/index.js
@@ -175,7 +175,7 @@ api.set = async ({
     // TODO: make these bedrock.config options
     rValue.algorithm = allOptions.algorithm.toUpperCase();
     rValue.digits = allOptions.digits;
-    rValue.period = allOptions.step;
+    rValue.step = allOptions.step;
       // produces a URL like `otpauth://totp/...`
     rValue.otpAuthUrl = authenticator.keyuri(
       rValue.label, rValue.service, rValue.secret

--- a/lib/index.js
+++ b/lib/index.js
@@ -80,6 +80,8 @@ api.set = async ({
   if(account && email) {
     throw new Error('Only "account" or "email" must be given.');
   }
+  await brPermissionCheck(
+    actor, PERMISSIONS.ACCOUNT_UPDATE, {resource: [account]});
 
   const token = {
     authenticationMethod,
@@ -153,8 +155,6 @@ api.set = async ({
     }
     secret = token.secret = authenticator.generateSecret();
   }
-  await brPermissionCheck(
-    actor, PERMISSIONS.ACCOUNT_UPDATE, {resource: [account]});
 
   // add token to meta
   const query = {};

--- a/lib/index.js
+++ b/lib/index.js
@@ -201,7 +201,7 @@ api.set = async ({
     // FIXME: use readable email and service name
     rValue.label = email || account;
     // a service name, `undefined` is OK if `serviceId` was not passed in
-    rvalue.service = serviceId;
+    rValue.service = serviceId;
     rValue.algorithm = 'SHA1';
     rValue.digits = 6;
     rValue.period = 30;

--- a/lib/index.js
+++ b/lib/index.js
@@ -204,7 +204,8 @@ api.set = async ({
   if(notify) {
     try {
       await api.notify({
-        actor, account, email, type, challenge, notification: {type: 'create'}
+        actor, account, email, type, authenticationMethod, challenge,
+        notification: {type: 'create'}
       });
     } catch(e) {
       logger.error('Failed to notify user of token creation.', {

--- a/lib/index.js
+++ b/lib/index.js
@@ -66,9 +66,9 @@ const PERMISSIONS = bedrock.config.permission.permissions;
  *   token details depending on the type.
  */
 api.set = async ({
-  actor, account, email, type, clientId, hash,
+  actor, account, email, type, clientId, serviceId, hash,
   authenticationMethod = type, requiredAuthenticationMethods = [],
-  serviceId, notify = true
+  notify = true
 } = {}) => {
   assert.optionalString(account, 'account');
   assert.optionalString(email, 'email');

--- a/lib/index.js
+++ b/lib/index.js
@@ -168,10 +168,11 @@ api.set = async ({
     // return TOTP params
     // algorithm, digits, period are defaults for otplib 'authenticator'
     rValue.secret = token.secret;
-      // FIXME: use readable email and service name
+    // FIXME: use readable email and service name
     rValue.label = email || account;
-      // a service name, `undefined` is OK if `serviceId` was not passed in
+    // a service name, `undefined` is OK if `serviceId` was not passed in
     rValue.service = serviceId;
+    // TODO: make these bedrock.config options
     rValue.algorithm = allOptions.algorithm.toUpperCase();
     rValue.digits = allOptions.digits;
     rValue.period = allOptions.step;

--- a/lib/notify.js
+++ b/lib/notify.js
@@ -13,13 +13,16 @@ require('./config');
 const api = {};
 module.exports = api;
 
-api.notify = async ({actor, account, email, type, challenge, notification}) => {
+api.notify = async ({
+  actor, account, email, type, authenticationMethod, challenge, notification
+}) => {
   // emit event for another module to handle
   const event = {
     actor,
     account,
     email,
     type,
+    authenticationMethod,
     challenge,
     notification
   };

--- a/test/mocha/20-totp.js
+++ b/test/mocha/20-totp.js
@@ -7,7 +7,7 @@ const brAccount = require('bedrock-account');
 const brAuthnToken = require('bedrock-authn-token');
 const helpers = require('./helpers.js');
 const mockData = require('./mock.data');
-const {totp} = require('otplib');
+const {authenticator} = require('otplib');
 
 describe('TOTP API', () => {
   describe('set', () => {
@@ -108,7 +108,7 @@ describe('TOTP API', () => {
       }));
     });
     it('should verify a valid token', async () => {
-      const challenge = totp.generate(secret);
+      const challenge = authenticator.generate(secret);
       let err;
       let result;
       try {
@@ -170,7 +170,7 @@ describe('TOTP API', () => {
       }));
     });
     it('should delete a secret', async () => {
-      let challenge = totp.generate(secret);
+      let challenge = authenticator.generate(secret);
       let err;
       let result;
       try {
@@ -205,7 +205,7 @@ describe('TOTP API', () => {
       should.not.exist(err);
 
       // attempt to validate the TOTP token again
-      challenge = totp.generate(secret);
+      challenge = authenticator.generate(secret);
       err = null;
       result = null;
       try {

--- a/test/mocha/20-totp.js
+++ b/test/mocha/20-totp.js
@@ -108,7 +108,7 @@ describe('TOTP API', () => {
       }));
     });
     it('should verify a valid token', async () => {
-      const totpToken = totp.generate(secret);
+      const challenge = totp.generate(secret);
       let err;
       let result;
       try {
@@ -116,7 +116,7 @@ describe('TOTP API', () => {
           account: accountId,
           actor,
           type: 'totp',
-          totpToken,
+          challenge,
         });
       } catch(e) {
         err = e;
@@ -130,8 +130,8 @@ describe('TOTP API', () => {
       });
     });
     it('should not verify an invalid token', async () => {
-      // an invalid random totpToken string
-      const totpToken = '91bc2849-2f43-4847-b5ad-01c0436b3a07';
+      // an invalid random challenge string
+      const challenge = '91bc2849-2f43-4847-b5ad-01c0436b3a07';
       let err;
       let result;
       try {
@@ -139,7 +139,7 @@ describe('TOTP API', () => {
           account: accountId,
           actor,
           type: 'totp',
-          totpToken,
+          challenge,
         });
       } catch(e) {
         err = e;
@@ -170,7 +170,7 @@ describe('TOTP API', () => {
       }));
     });
     it('should delete a secret', async () => {
-      let totpToken = totp.generate(secret);
+      let challenge = totp.generate(secret);
       let err;
       let result;
       try {
@@ -178,7 +178,7 @@ describe('TOTP API', () => {
           account: accountId,
           actor,
           type: 'totp',
-          totpToken,
+          challenge,
         });
       } catch(e) {
         err = e;
@@ -205,7 +205,7 @@ describe('TOTP API', () => {
       should.not.exist(err);
 
       // attempt to validate the TOTP token again
-      totpToken = totp.generate(secret);
+      challenge = totp.generate(secret);
       err = null;
       result = null;
       try {
@@ -213,7 +213,7 @@ describe('TOTP API', () => {
           account: accountId,
           actor,
           type: 'totp',
-          totpToken,
+          challenge,
         });
       } catch(e) {
         err = e;


### PR DESCRIPTION
- Return TOTP params for use when URL or QR Code won't work.
- Use otplib.authenticator to verify.
- Switch from `totpToken` to generic `challenge`.