### PR TITLE
Add `totp.window` config option.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # bedrock-authn-token ChangeLog
 
+### Added
+- `totp.window` config option to increase time step window. Default to accept
+  codes 1 time step in past and future.
+
 ## 1.2.0 - 2020-03-04
 
 ### Added

--- a/lib/config.js
+++ b/lib/config.js
@@ -18,6 +18,12 @@ cfg.nonce = {
   }
 };
 
+cfg.totp = {
+  // allow 1 time period window for code verification
+  // https://github.com/yeojz/otplib
+  window: 1
+};
+
 // a hash prefix is used for tokens to ensure that the stored hashes are
 // unique to the application (in the event that external systems also hash
 // the secret inputs for some other use case, the hashes stored on this

--- a/lib/index.js
+++ b/lib/index.js
@@ -422,6 +422,10 @@ api.verify = async ({
       new Buffer(token.sha256, 'base64'),
       new Buffer(prefixedHash(hash), 'base64'));
   } else if(type === 'totp') {
+    const cfg = config['authn-token'];
+    const {window} = cfg.totp;
+    // FIXME: create custom instance to just set these global options once
+    authenticator.options = {window};
     // test the totpToken provided to the API against the secret drawn from
     // the accounts database
     verified = authenticator.verify({token: challenge, secret: token.secret});


### PR DESCRIPTION
- Allows adjustment of past and/or future window where codes are accepted.
- Default to `1` to avoid common entry timeout problems.