### PR TITLE
Use bcrypt@4.0.1.

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "homepage": "https://github.com/digitalbazaar/bedrock-authn-token",
   "dependencies": {
     "assert-plus": "^1.0.0",
-    "bcrypt": "kelektiv/node.bcrypt.js#bbf0099fecaffc7c9553dba5d4b4311e2f98fe47",
+    "bcrypt": "^4.0.1",
     "fast-json-patch": "^3.0.0-1",
     "otplib": "^12.0.1"
   },


### PR DESCRIPTION
Fixes #14.

We switched to the pinned commit at a time when Node12 builds were failing.

bcrypt 4 now includes prebuilt binaries for node 12 (and other versions).

bcrypt is the only native dep that was being built in the wallet which was also producing compiler warnings etc.  Those are eliminated with this.

Unfortunately, there is zero test coverage for anything bcrypt related in this module.  However, according the the changelog, all changes have been related to switching to NAPI and dropping node 8 support etc.  No breaking API changes are described there.
