### PR TITLE
Use bcrypt@5.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # bedrock-authn-token ChangeLog
 
+## 2.1.0 - TBD
+
+### Changed
+- Use bcrypt@5.
+
 ## 2.0.0 - 2020-06-09
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "homepage": "https://github.com/digitalbazaar/bedrock-authn-token",
   "dependencies": {
     "assert-plus": "^1.0.0",
-    "bcrypt": "^4.0.1",
+    "bcrypt": "^5.0.0",
     "fast-json-patch": "^3.0.0-1",
     "otplib": "^12.0.1"
   },


### PR DESCRIPTION
We *just* upgraded to v4 and they *just* released v5.

https://github.com/kelektiv/node.bcrypt.js/blob/master/CHANGELOG.md#500-2020-06-02

do we even need bcrypt in our stack?