### PR TITLE
Update peerDeps to bedrock-mongodb.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Changed
 - **BREAKING**: `nonce` type tokens have a `maxCount` of 5, with 10 minute expiration for each.
 - Updated test deps to use bedrock-account@5.
+- Updated peerDeps to use bedrock-mongodb@8.1.1.
 
 ## 2.2.1 - 2020-07-07
 

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "peerDependencies": {
     "bedrock": "1.12.1 - 3.x",
     "bedrock-account": "^5.0.0",
-    "bedrock-mongodb": "^7.1.0",
+    "bedrock-mongodb": "^8.1.1",
     "bedrock-permission": "^3.0.0"
   },
   "directories": {


### PR DESCRIPTION
This is to minor to warrant a release or even an issue.
Bumps a peerDep for `bedrock-mongodb`