### PR TITLE
Add optional `authenticationOrigin` to `set()` and `setRecoveryEmail()`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # bedrock-authn-token ChangeLog
 
+## 12.1.0 - 2026-07-dd
+
+### Added
+- Add optional `requestOrigin` option to `set()` and `setRecoveryEmail()`; when
+  given, it is included in the `bedrock-authn-token.notify` and
+  `bedrock-authn-token.recoveryEmail.change` events.
+
 ## 12.0.0 - 2025-03-07
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,9 @@
 ## 12.1.0 - 2026-07-dd
 
 ### Added
-- Add optional `requestOrigin` option to `set()` and `setRecoveryEmail()`; when
-  given, it is included in the `bedrock-authn-token.notify` and
+- Add optional `authenticationOrigin` option to `set()` and
+  `setRecoveryEmail()`; an origin at which the user authenticates. When given,
+  it is included in the `bedrock-authn-token.notify` and
   `bedrock-authn-token.recoveryEmail.change` events.
 
 ## 12.0.0 - 2025-03-07

--- a/lib/notify.js
+++ b/lib/notify.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2018-2022 Digital Bazaar, Inc. All rights reserved.
+ * Copyright (c) 2018-2026 Digital Bazaar, Inc. All rights reserved.
  */
 import * as bedrock from '@bedrock/core';
 import '@bedrock/account';
@@ -8,7 +8,7 @@ import '@bedrock/account';
 import './config.js';
 
 export async function notify({
-  account, email, authenticationMethod, notification, token
+  account, email, authenticationMethod, notification, token, requestOrigin
 }) {
   // emit event for another module to handle
   const event = {
@@ -16,7 +16,8 @@ export async function notify({
     email,
     token,
     authenticationMethod,
-    notification
+    notification,
+    requestOrigin
   };
   await bedrock.events.emit('bedrock-authn-token.notify', event);
 }

--- a/lib/notify.js
+++ b/lib/notify.js
@@ -8,7 +8,8 @@ import '@bedrock/account';
 import './config.js';
 
 export async function notify({
-  account, email, authenticationMethod, notification, token, requestOrigin
+  account, email, authenticationMethod, authenticationOrigin,
+  notification, token
 }) {
   // emit event for another module to handle
   const event = {
@@ -17,7 +18,7 @@ export async function notify({
     token,
     authenticationMethod,
     notification,
-    requestOrigin
+    authenticationOrigin
   };
   await bedrock.events.emit('bedrock-authn-token.notify', event);
 }

--- a/lib/recovery.js
+++ b/lib/recovery.js
@@ -14,19 +14,19 @@ import {logger} from './logger.js';
  * @param {string} options.accountId - The ID of the account to set the
  *   recovery email for.
  * @param {string} options.recoveryEmail - The recovery email to set.
- * @param {string} [options.requestOrigin] - The origin header value from the
- *   client http request.
+ * @param {string} [options.authenticationOrigin] - An origin at which this
+ *   recovery email can be used to authenticate.
  * @param {boolean} [options.notify=true] - Set to `true` to notify the account
  *   user, `false` not to.
  *
  * @returns {Promise} - A Promise that resolves once the operation completes.
  */
 export async function setRecoveryEmail({
-  accountId, recoveryEmail, notify = true, requestOrigin
+  accountId, recoveryEmail, notify = true, authenticationOrigin
 } = {}) {
   assert.string(accountId, 'accountId');
   assert.string(recoveryEmail, 'recoveryEmail');
-  assert.optionalString(requestOrigin, 'requestOrigin');
+  assert.optionalString(authenticationOrigin, 'authenticationOrigin');
 
   // get the old recovery email and record sequence number
   const record = await brAccount.get({id: accountId});
@@ -42,7 +42,7 @@ export async function setRecoveryEmail({
       email: record.account.email,
       oldRecoveryEmail,
       newRecoveryEmail: recoveryEmail,
-      requestOrigin
+      authenticationOrigin
     };
 
     try {
@@ -53,7 +53,7 @@ export async function setRecoveryEmail({
         account: accountId,
         oldRecoveryEmail,
         newRecoveryEmail: recoveryEmail,
-        requestOrigin,
+        authenticationOrigin,
         error: e
       });
     }

--- a/lib/recovery.js
+++ b/lib/recovery.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2018-2022 Digital Bazaar, Inc. All rights reserved.
+ * Copyright (c) 2018-2026 Digital Bazaar, Inc. All rights reserved.
  */
 import * as bedrock from '@bedrock/core';
 import * as brAccount from '@bedrock/account';
@@ -14,16 +14,19 @@ import {logger} from './logger.js';
  * @param {string} options.accountId - The ID of the account to set the
  *   recovery email for.
  * @param {string} options.recoveryEmail - The recovery email to set.
+ * @param {string} [options.requestOrigin] - The origin header value from the
+ *   client http request.
  * @param {boolean} [options.notify=true] - Set to `true` to notify the account
  *   user, `false` not to.
  *
  * @returns {Promise} - A Promise that resolves once the operation completes.
  */
 export async function setRecoveryEmail({
-  accountId, recoveryEmail, notify = true
+  accountId, recoveryEmail, notify = true, requestOrigin
 } = {}) {
   assert.string(accountId, 'accountId');
   assert.string(recoveryEmail, 'recoveryEmail');
+  assert.optionalString(requestOrigin, 'requestOrigin');
 
   // get the old recovery email and record sequence number
   const record = await brAccount.get({id: accountId});
@@ -38,7 +41,8 @@ export async function setRecoveryEmail({
       account: accountId,
       email: record.account.email,
       oldRecoveryEmail,
-      newRecoveryEmail: recoveryEmail
+      newRecoveryEmail: recoveryEmail,
+      requestOrigin
     };
 
     try {
@@ -49,6 +53,7 @@ export async function setRecoveryEmail({
         account: accountId,
         oldRecoveryEmail,
         newRecoveryEmail: recoveryEmail,
+        requestOrigin,
         error: e
       });
     }

--- a/lib/tokens.js
+++ b/lib/tokens.js
@@ -34,8 +34,8 @@ const TESTER_CHALLENGE_TOKEN = '000000';
  *   `nonce`, or `totp`).
  * @param {string} [options.clientId] - An identifier for the client to bind a
  *   token to, if supported by the token type.
- * @param {string} [options.requestOrigin] - The origin header value from the
- *   client http request.
+ * @param {string} [options.authenticationOrigin] - An origin at which this
+ *   token can be used to authenticate.
  *  @param {string} [options.serviceId] - An identifier to associate with the
  *   token. For TOTP tokens, `serviceId` is encoded in the `otpAuthUrl` value
  *   returned by this API.
@@ -60,14 +60,14 @@ const TESTER_CHALLENGE_TOKEN = '000000';
  *   operation completes with token details depending on the type.
  */
 export async function set({
-  accountId, email, type, clientId, requestOrigin, serviceId,
+  accountId, email, type, clientId, authenticationOrigin, serviceId,
   hash, authenticationMethod = type, requiredAuthenticationMethods = [],
   notify = true, typeOptions = {entryStyle: 'human'}
 } = {}) {
   assert.optionalString(accountId, 'accountId');
   assert.optionalString(email, 'email');
   assert.optionalString(clientId, 'clientId');
-  assert.optionalString(requestOrigin, 'requestOrigin');
+  assert.optionalString(authenticationOrigin, 'authenticationOrigin');
   assert.optionalString(serviceId, 'serviceId');
   if(!(accountId || email) || (accountId && email)) {
     throw new Error('Exactly one of "accountId" or "email" is required.');
@@ -88,7 +88,7 @@ export async function set({
   if(notify) {
     try {
       await _notify({
-        accountId, email, authenticationMethod, requestOrigin,
+        accountId, email, authenticationMethod, authenticationOrigin,
         // only include `id`, `type`, and `challenge` information;
         // Note: `id` may be used in conjunction with `account`
         // or `email` in a deep link for authentication

--- a/lib/tokens.js
+++ b/lib/tokens.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2018-2023 Digital Bazaar, Inc. All rights reserved.
+ * Copyright (c) 2018-2026 Digital Bazaar, Inc. All rights reserved.
  */
 import * as bedrock from '@bedrock/core';
 import * as totp from '@digitalbazaar/totp';
@@ -34,6 +34,8 @@ const TESTER_CHALLENGE_TOKEN = '000000';
  *   `nonce`, or `totp`).
  * @param {string} [options.clientId] - An identifier for the client to bind a
  *   token to, if supported by the token type.
+ * @param {string} [options.requestOrigin] - The origin header value from the
+ *   client http request.
  *  @param {string} [options.serviceId] - An identifier to associate with the
  *   token. For TOTP tokens, `serviceId` is encoded in the `otpAuthUrl` value
  *   returned by this API.
@@ -58,13 +60,14 @@ const TESTER_CHALLENGE_TOKEN = '000000';
  *   operation completes with token details depending on the type.
  */
 export async function set({
-  accountId, email, type, clientId, serviceId,
+  accountId, email, type, clientId, requestOrigin, serviceId,
   hash, authenticationMethod = type, requiredAuthenticationMethods = [],
   notify = true, typeOptions = {entryStyle: 'human'}
 } = {}) {
   assert.optionalString(accountId, 'accountId');
   assert.optionalString(email, 'email');
   assert.optionalString(clientId, 'clientId');
+  assert.optionalString(requestOrigin, 'requestOrigin');
   assert.optionalString(serviceId, 'serviceId');
   if(!(accountId || email) || (accountId && email)) {
     throw new Error('Exactly one of "accountId" or "email" is required.');
@@ -85,7 +88,7 @@ export async function set({
   if(notify) {
     try {
       await _notify({
-        accountId, email, authenticationMethod,
+        accountId, email, authenticationMethod, requestOrigin,
         // only include `id`, `type`, and `challenge` information;
         // Note: `id` may be used in conjunction with `account`
         // or `email` in a deep link for authentication

--- a/test/mocha/07-setRecoveryEmail.js
+++ b/test/mocha/07-setRecoveryEmail.js
@@ -33,7 +33,7 @@ describe('setRecoveryEmail API', () => {
     should.exist(recoveryEmail);
     recoveryEmail.should.equal(expectedRecoveryEmail);
   });
-  it('should include "requestOrigin" in the recoveryEmail.change event',
+  it('should include "authenticationOrigin" in the recoveryEmail.change event',
     async () => {
       const accountId = mockData.accounts['alpha@example.com'].account.id;
       const expectedRecoveryEmail = 'alpha-recovery@example.com';
@@ -43,7 +43,7 @@ describe('setRecoveryEmail API', () => {
       try {
         await brAuthnToken.setRecoveryEmail({
           accountId,
-          requestOrigin: 'https://wallet.example',
+          authenticationOrigin: 'https://wallet.example',
           recoveryEmail: expectedRecoveryEmail
         });
       } finally {
@@ -55,7 +55,7 @@ describe('setRecoveryEmail API', () => {
       events.length.should.equal(1);
       const [event] = events;
       event.email.should.equal('alpha@example.com');
-      event.requestOrigin.should.equal('https://wallet.example');
+      event.authenticationOrigin.should.equal('https://wallet.example');
       event.newRecoveryEmail.should.equal(expectedRecoveryEmail);
     });
 });

--- a/test/mocha/07-setRecoveryEmail.js
+++ b/test/mocha/07-setRecoveryEmail.js
@@ -1,6 +1,7 @@
 /*!
- * Copyright (c) 2018-2023 Digital Bazaar, Inc. All rights reserved.
+ * Copyright (c) 2018-2026 Digital Bazaar, Inc. All rights reserved.
  */
+import * as bedrock from '@bedrock/core';
 import * as brAccount from '@bedrock/account';
 import * as brAuthnToken from '@bedrock/authn-token';
 import {mockData} from './mock.data.js';
@@ -32,4 +33,29 @@ describe('setRecoveryEmail API', () => {
     should.exist(recoveryEmail);
     recoveryEmail.should.equal(expectedRecoveryEmail);
   });
+  it('should include "requestOrigin" in the recoveryEmail.change event',
+    async () => {
+      const accountId = mockData.accounts['alpha@example.com'].account.id;
+      const expectedRecoveryEmail = 'alpha-recovery@example.com';
+      const events = [];
+      const listener = event => events.push(event);
+      bedrock.events.on('bedrock-authn-token.recoveryEmail.change', listener);
+      try {
+        await brAuthnToken.setRecoveryEmail({
+          accountId,
+          requestOrigin: 'https://wallet.example',
+          recoveryEmail: expectedRecoveryEmail
+        });
+      } finally {
+        bedrock.events.removeListener(
+          'bedrock-authn-token.recoveryEmail.change',
+          listener
+        );
+      }
+      events.length.should.equal(1);
+      const [event] = events;
+      event.email.should.equal('alpha@example.com');
+      event.requestOrigin.should.equal('https://wallet.example');
+      event.newRecoveryEmail.should.equal(expectedRecoveryEmail);
+    });
 });

--- a/test/mocha/20-nonce.js
+++ b/test/mocha/20-nonce.js
@@ -239,7 +239,7 @@ describe('Nonce API', () => {
       should.exist(result);
       result.id.should.equal(nonce1.id);
     });
-    it('should include "requestOrigin" in the notify event', async () => {
+    it('should include "authenticationOrigin" in the event', async () => {
       const accountId = mockData.accounts['alpha@example.com'].account.id;
       const events = [];
       const listener = event => events.push(event);
@@ -248,20 +248,20 @@ describe('Nonce API', () => {
         await brAuthnToken.set({
           accountId,
           type: 'nonce',
-          requestOrigin: 'https://wallet.example'
+          authenticationOrigin: 'https://wallet.example'
         });
       } finally {
         bedrock.events.removeListener('bedrock-authn-token.notify', listener);
       }
       events.length.should.equal(1);
       const [event] = events;
-      event.requestOrigin.should.equal('https://wallet.example');
+      event.authenticationOrigin.should.equal('https://wallet.example');
       // the rest of the event contract is unchanged
       should.exist(event.token);
       event.token.type.should.equal('nonce');
       event.authenticationMethod.should.equal('nonce');
     });
-    it('should not include "requestOrigin" in the notify event', async () => {
+    it('should not include "authenticationOrigin" in the event', async () => {
       const accountId = mockData.accounts['alpha@example.com'].account.id;
       const events = [];
       const listener = event => events.push(event);
@@ -276,7 +276,7 @@ describe('Nonce API', () => {
       }
       events.length.should.equal(1);
       const [event] = events;
-      should.not.exist(event.requestOrigin);
+      should.not.exist(event.authenticationOrigin);
       // the rest of the event contract is unchanged
       should.exist(event.token);
       event.token.type.should.equal('nonce');

--- a/test/mocha/20-nonce.js
+++ b/test/mocha/20-nonce.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2018-2023 Digital Bazaar, Inc. All rights reserved.
+ * Copyright (c) 2018-2026 Digital Bazaar, Inc. All rights reserved.
  */
 import * as bedrock from '@bedrock/core';
 import * as brAccount from '@bedrock/account';
@@ -238,6 +238,49 @@ describe('Nonce API', () => {
       });
       should.exist(result);
       result.id.should.equal(nonce1.id);
+    });
+    it('should include "requestOrigin" in the notify event', async () => {
+      const accountId = mockData.accounts['alpha@example.com'].account.id;
+      const events = [];
+      const listener = event => events.push(event);
+      bedrock.events.on('bedrock-authn-token.notify', listener);
+      try {
+        await brAuthnToken.set({
+          accountId,
+          type: 'nonce',
+          requestOrigin: 'https://wallet.example'
+        });
+      } finally {
+        bedrock.events.removeListener('bedrock-authn-token.notify', listener);
+      }
+      events.length.should.equal(1);
+      const [event] = events;
+      event.requestOrigin.should.equal('https://wallet.example');
+      // the rest of the event contract is unchanged
+      should.exist(event.token);
+      event.token.type.should.equal('nonce');
+      event.authenticationMethod.should.equal('nonce');
+    });
+    it('should not include "requestOrigin" in the notify event', async () => {
+      const accountId = mockData.accounts['alpha@example.com'].account.id;
+      const events = [];
+      const listener = event => events.push(event);
+      bedrock.events.on('bedrock-authn-token.notify', listener);
+      try {
+        await brAuthnToken.set({
+          accountId,
+          type: 'nonce',
+        });
+      } finally {
+        bedrock.events.removeListener('bedrock-authn-token.notify', listener);
+      }
+      events.length.should.equal(1);
+      const [event] = events;
+      should.not.exist(event.requestOrigin);
+      // the rest of the event contract is unchanged
+      should.exist(event.token);
+      event.token.type.should.equal('nonce');
+      event.authenticationMethod.should.equal('nonce');
     });
   });
   describe('verify', () => {


### PR DESCRIPTION
Adds an optional `authenticationOrigin` to `set()` and `setRecoveryEmail()` - an origin at which the resulting token (or recovery email) can be used to authenticate. When given, it is included in the `bedrock-authn-token.notify` and `bedrock-authn-token.recoveryEmail.change` events. Additive - no existing caller's behavior changes. Release as 12.1.0.